### PR TITLE
SLIDESNET-44812: The `TextHelper.GetParentShape()` method is replaced with the `TextFrame.ParentShape` property

### DIFF
--- a/Aspose.Slides.WebExtensions/Aspose.Slides.WebExtensions.csproj
+++ b/Aspose.Slides.WebExtensions/Aspose.Slides.WebExtensions.csproj
@@ -109,7 +109,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspose.Slides.NET" Version="24.10.0" />
+    <PackageReference Include="Aspose.Slides.NET" Version="25.3.0" />
     <PackageReference Include="MimeTypesMap" Version="1.0.8" />
     <PackageReference Include="RazorEngineCore" Version="2023.11.2" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />

--- a/Aspose.Slides.WebExtensions/Helpers/TextHelper.cs
+++ b/Aspose.Slides.WebExtensions/Helpers/TextHelper.cs
@@ -304,7 +304,7 @@ namespace Aspose.Slides.WebExtensions.Helpers
                                              NumberHelper.ToCssNumber(shadowFix * format.EffectFormat.OuterShadowEffect.Distance * Math.Sin((Math.PI / 180) * format.EffectFormat.OuterShadowEffect.Direction)),
                                              NumberHelper.ToCssNumber(format.EffectFormat.OuterShadowEffect.BlurRadius),
                                              ColorHelper.GetRrbaColorString(format.EffectFormat.OuterShadowEffect.ShadowColor)));
-            IShape shp = GetParentShape(parentTextFrame);
+            IShape shp = parentTextFrame.ParentShape;
             if (shp != null)
             {
                 var outerShadow = shp.EffectFormat.OuterShadowEffect;
@@ -330,17 +330,6 @@ namespace Aspose.Slides.WebExtensions.Helpers
             }
             if (text_shadows.Count > 0) return string.Format("text-shadow: {0};", string.Join(", ", text_shadows.ToArray()));
             else return "";
-        }
-
-        private static IShape GetParentShape(TextFrame parentTextFrame)
-        {
-            IBaseSlide slide = parentTextFrame.Slide;
-            foreach(IShape shp in slide.Shapes)
-            {
-                if (shp is AutoShape && parentTextFrame == (shp as AutoShape).TextFrame)
-                    return shp;
-            }
-            return null;
         }
 
         public static string GetTextStyle(IParagraphFormatEffectiveData format, TemplateContext<Paragraph> model)

--- a/Examples/SinglePageApp/SinglePageApp.csproj
+++ b/Examples/SinglePageApp/SinglePageApp.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Aspose.Slides.NET">
-      <Version>24.10.0</Version>
+      <Version>25.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- The `TextHelper.GetParentShape()` method is replaced with the `TextFrame.ParentShape` property
- Dependencies are updated