### PR TITLE
SLIDESNET-44929: Fixed HTML5 export of CalloutWedgeEllipse callouts

### DIFF
--- a/Aspose.Slides.WebExtensions/Helpers/ShapeHelper.cs
+++ b/Aspose.Slides.WebExtensions/Helpers/ShapeHelper.cs
@@ -108,7 +108,7 @@ namespace Aspose.Slides.WebExtensions.Helpers
                 try
                 {
                     autoShape.TextFrame.Paragraphs.Clear();
-                    thumbnail = UsesAppearanceBounds(autoShape)
+                    thumbnail = ShouldUseAppearanceBounds(autoShape)
                         ? autoShape.GetImage(ShapeThumbnailBounds.Appearance, 1, 1)
                         : autoShape.GetImage();
                 }
@@ -166,7 +166,7 @@ namespace Aspose.Slides.WebExtensions.Helpers
                 imageBounds.Height);
         }
 
-        public static bool UsesAppearanceBounds(Shape shape)
+        public static bool ShouldUseAppearanceBounds(Shape shape)
         {
             AutoShape autoShape = shape as AutoShape;
             if (autoShape == null)

--- a/Aspose.Slides.WebExtensions/Helpers/ShapeHelper.cs
+++ b/Aspose.Slides.WebExtensions/Helpers/ShapeHelper.cs
@@ -108,7 +108,9 @@ namespace Aspose.Slides.WebExtensions.Helpers
                 try
                 {
                     autoShape.TextFrame.Paragraphs.Clear();
-                    thumbnail = autoShape.GetImage();
+                    thumbnail = UsesAppearanceBounds(autoShape)
+                        ? autoShape.GetImage(ShapeThumbnailBounds.Appearance, 1, 1)
+                        : autoShape.GetImage();
                 }
                 finally
                 {
@@ -149,5 +151,115 @@ namespace Aspose.Slides.WebExtensions.Helpers
             }
             return string.Format("left: {0}px; top: {1}px; width: {2}px; height: {3}px;", left, top, width, height);
         }
+
+        public static string GetShapeImagePositionStyle(Shape shape)
+        {
+            Rectangle imageBounds = GetShapeAppearanceBounds(shape);
+            if (imageBounds == Rectangle.Empty)
+                imageBounds = Rectangle.Round(new RectangleF(shape.X, shape.Y, shape.Width, shape.Height));
+
+            return string.Format(
+                "position: absolute; z-index: 0; left: {0}px; top: {1}px; width: {2}px; height: {3}px;",
+                (int)Math.Floor(imageBounds.Left - shape.X),
+                (int)Math.Floor(imageBounds.Top - shape.Y),
+                imageBounds.Width,
+                imageBounds.Height);
+        }
+
+        public static bool UsesAppearanceBounds(Shape shape)
+        {
+            AutoShape autoShape = shape as AutoShape;
+            if (autoShape == null)
+                return false;
+
+            switch (autoShape.ShapeType)
+            {
+                case ShapeType.CalloutWedgeRectangle:
+                case ShapeType.CalloutWedgeRoundRectangle:
+                case ShapeType.CalloutWedgeEllipse:
+                case ShapeType.CalloutCloud:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static RectangleF GetCalloutTextBounds(Shape shape)
+        {
+            AutoShape autoShape = shape as AutoShape;
+            if (autoShape == null)
+                return new RectangleF(0, 0, shape.Width, shape.Height);
+
+            switch (autoShape.ShapeType)
+            {
+                case ShapeType.CalloutWedgeEllipse:
+                    const float horizontalInsetRatio = 0.146f;
+                    float horizontalInset = shape.Width * horizontalInsetRatio;
+                    return new RectangleF(horizontalInset, 0, shape.Width - 2 * horizontalInset, shape.Height);
+                default:
+                    return new RectangleF(0, 0, shape.Width, shape.Height);
+            }
+        }
+
+        private static Rectangle GetShapeAppearanceBounds(Shape shape)
+        {
+            AutoShape autoShape = shape as AutoShape;
+            if (autoShape != null && autoShape.TextFrame != null && !string.IsNullOrEmpty(autoShape.TextFrame.Text))
+            {
+                List<Paragraph> paragraphs = new List<Paragraph>();
+                foreach (Paragraph paragraph in autoShape.TextFrame.Paragraphs)
+                    paragraphs.Add(new Paragraph(paragraph));
+
+                try
+                {
+                    autoShape.TextFrame.Paragraphs.Clear();
+                    return GetShapeAppearanceBoundsWithoutText(autoShape);
+                }
+                finally
+                {
+                    foreach (Paragraph paragraph in paragraphs)
+                        autoShape.TextFrame.Paragraphs.Add(paragraph);
+                }
+            }
+
+            return GetShapeAppearanceBoundsWithoutText(shape);
+        }
+
+        private static Rectangle GetShapeAppearanceBoundsWithoutText(Shape shape)
+        {
+            using (IImage image = shape.GetImage(ShapeThumbnailBounds.Slide, 1, 1))
+            using (MemoryStream stream = new MemoryStream())
+            {
+                image.Save(stream, Aspose.Slides.ImageFormat.Png);
+                stream.Position = 0;
+
+                using (Bitmap bitmap = new Bitmap(stream))
+                {
+                    int left = bitmap.Width;
+                    int top = bitmap.Height;
+                    int right = -1;
+                    int bottom = -1;
+
+                    for (int y = 0; y < bitmap.Height; y++)
+                    {
+                        for (int x = 0; x < bitmap.Width; x++)
+                        {
+                            if (bitmap.GetPixel(x, y).A == 0)
+                                continue;
+
+                            left = Math.Min(left, x);
+                            top = Math.Min(top, y);
+                            right = Math.Max(right, x);
+                            bottom = Math.Max(bottom, y);
+                        }
+                    }
+
+                    return right < left || bottom < top
+                        ? Rectangle.Empty
+                        : Rectangle.FromLTRB(left, top, right + 1, bottom + 1);
+                }
+            }
+        }
+
     }
 }

--- a/Aspose.Slides.WebExtensions/Helpers/TextHelper.cs
+++ b/Aspose.Slides.WebExtensions/Helpers/TextHelper.cs
@@ -79,7 +79,7 @@ namespace Aspose.Slides.WebExtensions.Helpers
 
             if (!verticalText)
             {
-                if (ShapeHelper.UsesAppearanceBounds(parentShape))
+                if (ShapeHelper.ShouldUseAppearanceBounds(parentShape))
                 {
                     RectangleF textBounds = ShapeHelper.GetCalloutTextBounds(parentShape);
 

--- a/Aspose.Slides.WebExtensions/Helpers/TextHelper.cs
+++ b/Aspose.Slides.WebExtensions/Helpers/TextHelper.cs
@@ -64,14 +64,8 @@ namespace Aspose.Slides.WebExtensions.Helpers
             var textFrameFormatEffective = textFrame.TextFrameFormat.GetEffective();
 
             float paraHeights = 0;
-            float maxParaWidth = float.MinValue;
             foreach (var para in textFrame.Paragraphs)
-            {
-                var paraRect = para.GetRect();
-                paraHeights += paraRect.Height;
-                if (paraRect.Width > maxParaWidth)
-                    maxParaWidth = paraRect.Width;
-            }
+                paraHeights += para.GetRect().Height;
 
             bool verticalText = textFrameFormatEffective.TextVerticalType == TextVerticalType.Vertical
                                 || textFrameFormatEffective.TextVerticalType == TextVerticalType.WordArtVertical
@@ -79,10 +73,31 @@ namespace Aspose.Slides.WebExtensions.Helpers
 
             double paddingTop = 0;
             double paddingLeft = 0;
+            string textFrameBoundsStyle = "";
+            string verticalAlignmentStyle = "";
             string writingModeStyle = "";
 
             if (!verticalText)
             {
+                if (ShapeHelper.UsesAppearanceBounds(parentShape))
+                {
+                    RectangleF textBounds = ShapeHelper.GetCalloutTextBounds(parentShape);
+
+                    // Paragraph margins are emitted as CSS margins, so they must remain part of
+                    // the text frame width. Subtracting them here makes the browser apply them twice.
+                    double textWidth = textBounds.Width;
+
+                    if (textFrameFormatEffective.AnchoringType == TextAnchorType.Center)
+                    {
+                        verticalAlignmentStyle = string.Format(
+                            "height: {0}px; display: flex; flex-direction: column; justify-content: center;",
+                            (int)Math.Ceiling(parentShape.Height));
+                    }
+
+                    paddingLeft = textBounds.Left + textFrameFormatEffective.MarginLeft;
+                    textFrameBoundsStyle = string.Format("width: {0}px;", (int)Math.Ceiling(textWidth));
+                }
+
                 switch (textFrameFormatEffective.AnchoringType)
                 {
                     case TextAnchorType.Bottom:
@@ -92,6 +107,9 @@ namespace Aspose.Slides.WebExtensions.Helpers
                         paddingTop = (parentShape.Height - paraHeights - textFrameFormatEffective.MarginTop - textFrameFormatEffective.MarginBottom) / 2;
                         break;
                 }
+
+                if (!string.IsNullOrEmpty(verticalAlignmentStyle))
+                    paddingTop = 0;
             }
             else
             {
@@ -117,7 +135,7 @@ namespace Aspose.Slides.WebExtensions.Helpers
             string paddingTopStyle = string.Format("padding-top: {0}px;", (int)paddingTop);
             string paddingLeftStyle = string.Format("padding-left: {0}px;", (int)paddingLeft);
 
-            return string.Join(" ", new string[] { paddingTopStyle, paddingLeftStyle, writingModeStyle });
+            return string.Join(" ", new string[] { paddingTopStyle, paddingLeftStyle, textFrameBoundsStyle, verticalAlignmentStyle, writingModeStyle });
         }
 
         public static string GetHorizontalAlignmentStyle(TextAlignment textAlignment)

--- a/Aspose.Slides.WebExtensions/Templates/common/shape.html
+++ b/Aspose.Slides.WebExtensions/Templates/common/shape.html
@@ -8,6 +8,7 @@
     var textStyle = "position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);";
 
     string imgSrc = ShapeHelper.GetShapeAsImageURL<Shape>(contextObject, Model);
+    bool useAppearanceBounds = ShapeHelper.UsesAppearanceBounds(contextObject);
 
     string id = "slide-" + contextObject.Slide.SlideId + "-shape-" + contextObject.UniqueId;
     string animationAttributes = "";
@@ -17,12 +18,21 @@
         animationAttributes = Model.Local.Get<string>("animationAttributes");
     }
 
-    var shapeStyle = positionStyle + " background-image: " + imgSrc + "; background-size: 100% 100%;";
+    var shapeStyle = positionStyle;
+    if (!useAppearanceBounds)
+        shapeStyle += " background-image: " + imgSrc + "; background-size: 100% 100%;";
     shapeStyle += String.Format(" transform: rotate({0}deg);", (int)contextObject.Rotation);
+    var imageStyle = useAppearanceBounds
+        ? ShapeHelper.GetShapeImagePositionStyle(contextObject) + " background-image: " + imgSrc + "; background-size: 100% 100%;"
+        : "";
 }
 
 @{
     <div class="shape" id="@id" style="@Raw(shapeStyle)" @Raw(animationAttributes)>
+        @if (useAppearanceBounds)
+        {
+        <div style="@Raw(imageStyle)"></div>
+        }
         @if (contextObject is AutoShape)
         {
         AutoShape shape = contextObject as AutoShape;

--- a/Aspose.Slides.WebExtensions/Templates/common/shape.html
+++ b/Aspose.Slides.WebExtensions/Templates/common/shape.html
@@ -8,7 +8,7 @@
     var textStyle = "position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);";
 
     string imgSrc = ShapeHelper.GetShapeAsImageURL<Shape>(contextObject, Model);
-    bool useAppearanceBounds = ShapeHelper.UsesAppearanceBounds(contextObject);
+    bool useAppearanceBounds = ShapeHelper.ShouldUseAppearanceBounds(contextObject);
 
     string id = "slide-" + contextObject.Slide.SlideId + "-shape-" + contextObject.UniqueId;
     string animationAttributes = "";

--- a/Aspose.Slides.WebExtensions/Templates/common/textframe.html
+++ b/Aspose.Slides.WebExtensions/Templates/common/textframe.html
@@ -19,7 +19,7 @@
         var parentShape = Model.Local.Get<AutoShape>("parent");
         string positioningStyle = TextHelper.GetTextPositioningStyle(textFrame, parentShape);
         string columnsParameters = TextHelper.GetTextFrameColumnsStyle(textFrame.TextFrameFormat.GetEffective());
-        string foregroundStyle = ShapeHelper.UsesAppearanceBounds(parentShape)
+        string foregroundStyle = ShapeHelper.ShouldUseAppearanceBounds(parentShape)
             ? "position: relative; z-index: 1;"
             : "";
         if (UseWideTextBoxLayout(textFrame, parentShape))

--- a/Aspose.Slides.WebExtensions/Templates/common/textframe.html
+++ b/Aspose.Slides.WebExtensions/Templates/common/textframe.html
@@ -19,6 +19,9 @@
         var parentShape = Model.Local.Get<AutoShape>("parent");
         string positioningStyle = TextHelper.GetTextPositioningStyle(textFrame, parentShape);
         string columnsParameters = TextHelper.GetTextFrameColumnsStyle(textFrame.TextFrameFormat.GetEffective());
+        string foregroundStyle = ShapeHelper.UsesAppearanceBounds(parentShape)
+            ? "position: relative; z-index: 1;"
+            : "";
         if (UseWideTextBoxLayout(textFrame, parentShape))
         {
             positioningStyle = string.Format(
@@ -26,7 +29,7 @@
                 NumberHelper.ToCssNumber(textFrame.TextFrameFormat.GetEffective().MarginTop));
         }
 
-        return string.Join(" ", new string[] {positioningStyle, columnsParameters});
+        return string.Join(" ", new string[] {positioningStyle, columnsParameters, foregroundStyle});
     }
 
     bool UseWideTextBoxLayout(TextFrame textFrame, AutoShape parentShape)


### PR DESCRIPTION
Fixed HTML5 export of CalloutWedgeEllipse callouts: shapes are no longer cropped, and text is correctly centered and wrapped.