### PR TITLE
SLIDESNET-44573: Add audio support for HTML5 animation export

### DIFF
--- a/Aspose.Slides.WebExtensions/Aspose.Slides.WebExtensions.csproj
+++ b/Aspose.Slides.WebExtensions/Aspose.Slides.WebExtensions.csproj
@@ -109,7 +109,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspose.Slides.NET" Version="26.3.0" />
+    <PackageReference Include="Aspose.Slides.NET" Version="26.8.0" />
     <PackageReference Include="MimeTypesMap" Version="1.0.9" />
     <PackageReference Include="RazorEngineCore" Version="2026.1.1" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />

--- a/Aspose.Slides.WebExtensions/Helpers/SlideHelper.cs
+++ b/Aspose.Slides.WebExtensions/Helpers/SlideHelper.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using Aspose.Slides.Animation;
 using Aspose.Slides.Export;
 using Aspose.Slides.Export.Web;
@@ -128,9 +129,9 @@ namespace Aspose.Slides.WebExtensions.Helpers
             return result;
         }
 
-        public static Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int>>> GetSlidesAnimationCollection(ISlide slide)
+        public static Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int, IAudio>>> GetSlidesAnimationCollection(ISlide slide)
         {
-            var result = new Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int>>>();
+            var result = new Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int, IAudio>>>();
 
             int onclickIndex = 0;
             onclickIndex = FillSequenceEffectCollection(slide.LayoutSlide.MasterSlide.Timeline.MainSequence, result, null, onclickIndex);
@@ -147,9 +148,9 @@ namespace Aspose.Slides.WebExtensions.Helpers
             return result;
         }
 
-        public static Dictionary<IParagraph, Tuple<string, string, float, float, string, string, int>> GetSlidesParagraphAnimationCollection(ISlide slide)
+        public static Dictionary<IParagraph, Tuple<string, string, float, float, string, string, int, IAudio>> GetSlidesParagraphAnimationCollection(ISlide slide)
         {
-            var result = new Dictionary<IParagraph, Tuple<string, string, float, float, string, string, int>>();
+            var result = new Dictionary<IParagraph, Tuple<string, string, float, float, string, string, int, IAudio>>();
 
             int onclickIndex = 0;
             onclickIndex = FillSequenceEffectCollection(slide.LayoutSlide.MasterSlide.Timeline.MainSequence, null, result, onclickIndex);
@@ -168,8 +169,8 @@ namespace Aspose.Slides.WebExtensions.Helpers
 
         private static int FillSequenceEffectCollection(
             ISequence sequence,
-            Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int>>> shapeEffectsCollection,
-            Dictionary<IParagraph, Tuple<string, string, float, float, string, string, int>> paragraphEffectsCollection,
+            Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int, IAudio>>> shapeEffectsCollection,
+            Dictionary<IParagraph, Tuple<string, string, float, float, string, string, int, IAudio>> paragraphEffectsCollection,
             int onclickIndex)
         {
             float prevDelay = 0;
@@ -265,14 +266,15 @@ namespace Aspose.Slides.WebExtensions.Helpers
                     extra = GetDestinationColor(shape, toColor);
 
                 IParagraph paragraph = GetEffectParagraph(sequence, effect);
-                var effectData = new Tuple<string, string, float, float, string, string, int>(
+                var effectData = new Tuple<string, string, float, float, string, string, int, IAudio>(
                     classType.ToString() + type.ToString(),
                     subType.ToString(),
                     duration,
                     totalDelay,
                     targetShapeId,
                     extra,
-                    onclickIndex);
+                    onclickIndex,
+                    effect.Sound);
 
                 if (paragraph != null)
                 {
@@ -282,7 +284,7 @@ namespace Aspose.Slides.WebExtensions.Helpers
                 else if (shapeEffectsCollection != null)
                 {
                     if (!shapeEffectsCollection.ContainsKey(shape))
-                        shapeEffectsCollection.Add(shape, new List<Tuple<string, string, float, float, string, string, int>>());
+                        shapeEffectsCollection.Add(shape, new List<Tuple<string, string, float, float, string, string, int, IAudio>>());
 
                     shapeEffectsCollection[shape].Add(effectData);
                 }
@@ -437,5 +439,16 @@ namespace Aspose.Slides.WebExtensions.Helpers
             slideHeght = frameHeight.ToString();
             if (!handoutIsSet) slideHandoutStyles = "";
         }
+
+        public static string GetAudioURL<T>(IAudio audio, TemplateContext<T> model)
+        {
+            if (audio == null || audio.BinaryData == null || audio.BinaryData.Length == 0)
+                return string.Empty;
+
+            string audioPath = model.Output.GetResourcePath(audio);
+            string slidesPath = model.Global.Get<string>("slidesPath");
+            return ShapeHelper.ConvertPathToRelative(audioPath, slidesPath);
+        }
+
     }
 }

--- a/Aspose.Slides.WebExtensions/PresentationExtensions.cs
+++ b/Aspose.Slides.WebExtensions/PresentationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2001-2020 Aspose Pty Ltd. All Rights Reserved.
 
 using Aspose.Slides.Charts;
+using Aspose.Slides.Animation;
 using Aspose.Slides.Export;
 using Aspose.Slides.Export.Web;
 using Aspose.Slides.WebExtensions.Helpers;
@@ -327,6 +328,7 @@ namespace Aspose.Slides.WebExtensions
 
             document.AddEmbeddedFontsOutput(document.Global.Get<string>("fontsPath"), pres);
             document.AddVideoOutput(document.Global.Get<string>("mediaPath"), pres);
+            SlideHelper.AddAudioOutput(document, document.Global.Get<string>("mediaPath"), pres);
 
             if (!options.EmbedImages)
             {
@@ -497,6 +499,54 @@ namespace Aspose.Slides.WebExtensions
                 var outputFile = document.Output.Add(path, video);
                 document.Output.BindResource(outputFile, video);
             }
+        }
+        public static void AddAudioOutput(this WebDocument document, string outputPath, Presentation pres)
+        {
+            var audioCollection = new List<IAudio>();
+            foreach (Slide slide in pres.Slides)
+            {
+                CollectAudio(slide.Timeline.MainSequence, audioCollection);
+                foreach (ISequence sequence in slide.Timeline.InteractiveSequences)
+                    CollectAudio(sequence, audioCollection);
+
+                CollectAudio(slide.LayoutSlide.Timeline.MainSequence, audioCollection);
+                foreach (ISequence sequence in slide.LayoutSlide.Timeline.InteractiveSequences)
+                    CollectAudio(sequence, audioCollection);
+
+                CollectAudio(slide.LayoutSlide.MasterSlide.Timeline.MainSequence, audioCollection);
+                foreach (ISequence sequence in slide.LayoutSlide.MasterSlide.Timeline.InteractiveSequences)
+                    CollectAudio(sequence, audioCollection);
+            }
+
+            for (int i = 0; i < audioCollection.Count; i++)
+            {
+                IAudio audio = audioCollection[i];
+                string path = Path.Combine(outputPath, string.Format("audio{0}.{1}", i, GetAudioFileExtension(audio.ContentType)));
+                var outputFile = document.Output.Add(path, audio);
+                document.Output.BindResource(outputFile, audio);
+            }
+        }
+
+        private static void CollectAudio(ISequence sequence, List<IAudio> audioCollection)
+        {
+            foreach (IEffect effect in sequence)
+            {
+                if (effect.Sound != null && !audioCollection.Contains(effect.Sound))
+                    audioCollection.Add(effect.Sound);
+            }
+        }
+
+        private static string GetAudioFileExtension(string contentType)
+        {
+            if (string.Equals(contentType, "audio/mpeg", StringComparison.OrdinalIgnoreCase))
+                return "mp3";
+            if (string.Equals(contentType, "audio/x-wav", StringComparison.OrdinalIgnoreCase))
+                return "wav";
+
+            int separatorIndex = contentType == null ? -1 : contentType.IndexOf('/');
+            return separatorIndex >= 0 && separatorIndex < contentType.Length - 1
+                ? contentType.Substring(separatorIndex + 1)
+                : "wav";
         }
 
         public static void AddScriptsOutput(this WebDocument document, string outputPath, string inputFile, string scriptName)

--- a/Aspose.Slides.WebExtensions/Templates/common/scripts/animation.js
+++ b/Aspose.Slides.WebExtensions/Templates/common/scripts/animation.js
@@ -225,13 +225,14 @@ function FillSlideShapeAnimations(slideId) {
                 while (animations[clickTarget].length <= animationIndex)
                     animations[clickTarget].push([]);
 
-                animations[clickTarget][animationIndex].push(GetAnimationEffect(
+                animations[clickTarget][animationIndex].push(GetAnimationEffectWithSound(
                     $(this).attr("data-animation-type" + attrSuffix),
                     $(this).attr("data-animation-subtype" + attrSuffix),
                     '#' + this.id,
                     $(this).attr("data-animation-duration" + attrSuffix),
                     $(this).attr("data-animation-delay" + attrSuffix),
-                    $(this).attr("data-animation-extra" + attrSuffix)));
+                    $(this).attr("data-animation-extra" + attrSuffix),
+                    $(this).attr("data-animation-sound" + attrSuffix)));
             }
         }
     });
@@ -249,10 +250,29 @@ function CreateAnimationEffects(animatedShapesId) {
     
     var result = [];
     for (var i = 0; i < animatedShapesId.length; i++) {
-        result.push(GetAnimationEffect($(animatedShapesId[i]).data("animation-type"), $(animatedShapesId[i]).data("animation-subtype"),animatedShapesId[i], $(animatedShapesId[i]).data("animation-duration"), $(animatedShapesId[i]).data("animation-delay"), $(animatedShapesId[i]).data("animation-extra")));
+        result.push(GetAnimationEffectWithSound($(animatedShapesId[i]).data("animation-type"), $(animatedShapesId[i]).data("animation-subtype"),animatedShapesId[i], $(animatedShapesId[i]).data("animation-duration"), $(animatedShapesId[i]).data("animation-delay"), $(animatedShapesId[i]).data("animation-extra"), $(animatedShapesId[i]).data("animation-sound")));
     }
     
     return result;
+}
+
+function GetAnimationEffectWithSound(type, subtype, shapeId, duration, delay, extra, sound) {
+    var effect = GetAnimationEffect(type, subtype, shapeId, duration, delay, extra);
+    effect.sound = sound;
+    effect.soundDelay = parseFloat(delay) * 1000;
+    return effect;
+}
+
+function PlayEffectSound(sound, delay) {
+    if (sound == null || sound === '')
+        return;
+
+    window.setTimeout(function() {
+        var audio = new Audio(sound);
+        var playback = audio.play();
+        if (playback != null)
+            playback.catch(function() {});
+    }, isNaN(delay) ? 0 : delay);
 }
 
 function PauseAllEffects(animations) {
@@ -474,8 +494,10 @@ function RestartEffectsTimeline(effectsCollection) {
 
 function PlayEffectsTimeline(effectsCollection) {
     if (effectsCollection != null)
-        for (var i = 0; i < effectsCollection.length; i++)
+        for (var i = 0; i < effectsCollection.length; i++) {
             effectsCollection[i].Play();
+            PlayEffectSound(effectsCollection[i].sound, effectsCollection[i].soundDelay);
+        }
 }
 
 function RestoreEffectsTimeline(effectsCollection) {

--- a/Aspose.Slides.WebExtensions/Templates/common/textframe.html
+++ b/Aspose.Slides.WebExtensions/Templates/common/textframe.html
@@ -9,7 +9,7 @@
     var slide = parentAutoShape.Slide as ISlide;
     var paragraphAnimationData = (contextObject != null && slide != null)
         ? SlideHelper.GetSlidesParagraphAnimationCollection(slide)
-        : new Dictionary<IParagraph, Tuple<string, string, float, float, string, string, int>>();
+        : new Dictionary<IParagraph, Tuple<string, string, float, float, string, string, int, IAudio>>();
 }
 
 @functions
@@ -69,6 +69,7 @@
             animationAttributes += "data-animation-delay=\"" + NumberHelper.ToCssNumber(paragraphAnimation.Item4) + "\" ";
             animationAttributes += "data-animation-clickTarget=\"" + paragraphAnimation.Item5 + "\" ";
             animationAttributes += "data-animation-extra=\"" + paragraphAnimation.Item6 + "\" ";
+            animationAttributes += "data-animation-sound=\"" + SlideHelper.GetAudioURL(paragraphAnimation.Item8, Model) + "\" ";
             animationAttributes += "data-animation-index=\"" + paragraphAnimation.Item7 + "\" ";
 
             string animationId = "slide-" + slide.SlideId + "-shape-" + parentAutoShape.UniqueId + "-paragraph-" + i;

--- a/Aspose.Slides.WebExtensions/Templates/single-page-embedded/slide.html
+++ b/Aspose.Slides.WebExtensions/Templates/single-page-embedded/slide.html
@@ -10,7 +10,7 @@
 }
 
 @{
-    void EmitShape(IShape shape, Slide contextObject, bool animateTransitions, int slideNumber, Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int>>> slideAnimationData)
+    void EmitShape(IShape shape, Slide contextObject, bool animateTransitions, int slideNumber, Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int, IAudio>>> slideAnimationData)
 {
     var margin = Model.Global.Get<int>("slideMargin");
     var visibleSlideNumber = animateTransitions ? 1 : slideNumber;
@@ -31,6 +31,7 @@
             animationAttributes += "data-animation-delay=\"" + NumberHelper.ToCssNumber(shapeAnimationData.Item4) + "\" ";
             animationAttributes += "data-animation-clickTarget=\"" + shapeAnimationData.Item5 + "\" ";
             animationAttributes += "data-animation-extra=\"" + shapeAnimationData.Item6 + "\" ";
+            animationAttributes += "data-animation-sound=\"" + SlideHelper.GetAudioURL(shapeAnimationData.Item8, Model) + "\" ";
             animationAttributes += "data-animation-index=\"" + shapeAnimationData.Item7 + "\" ";
         }
         else
@@ -45,6 +46,7 @@
                 animationAttributes += "data-animation-delay-" + i + "=\"" + NumberHelper.ToCssNumber(shapeAnimationData.Item4) + "\" ";
                 animationAttributes += "data-animation-clickTarget-" + i + "=\"" + shapeAnimationData.Item5 + "\" ";
                 animationAttributes += "data-animation-extra-" + i + "=\"" + shapeAnimationData.Item6 + "\" ";
+                animationAttributes += "data-animation-sound-" + i + "=\"" + SlideHelper.GetAudioURL(shapeAnimationData.Item8, Model) + "\" ";
                 animationAttributes += "data-animation-index-" + i + "=\"" + shapeAnimationData.Item7 + "\" ";
             }
         }

--- a/Aspose.Slides.WebExtensions/Templates/single-page-navigation/slide.html
+++ b/Aspose.Slides.WebExtensions/Templates/single-page-navigation/slide.html
@@ -8,7 +8,7 @@
 }
 
 @{
-    void EmitShape(IShape shape, Slide contextObject, Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int>>> slideAnimationData)
+    void EmitShape(IShape shape, Slide contextObject, Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int, IAudio>>> slideAnimationData)
 {
     var margin = Model.Global.Get<int>("slideMargin");
     var origin = new Point(0, 0);
@@ -27,6 +27,7 @@
             animationAttributes += "data-animation-delay=\"" + NumberHelper.ToCssNumber(shapeAnimationData.Item4) + "\" ";
             animationAttributes += "data-animation-clickTarget=\"" + shapeAnimationData.Item5 + "\" ";
             animationAttributes += "data-animation-extra=\"" + shapeAnimationData.Item6 + "\" ";
+            animationAttributes += "data-animation-sound=\"" + SlideHelper.GetAudioURL(shapeAnimationData.Item8, Model) + "\" ";
             animationAttributes += "data-animation-index=\"" + shapeAnimationData.Item7 + "\" ";
         }
         else
@@ -41,6 +42,7 @@
                 animationAttributes += "data-animation-delay-" + i + "=\"" + NumberHelper.ToCssNumber(shapeAnimationData.Item4) + "\" ";
                 animationAttributes += "data-animation-clickTarget-" + i + "=\"" + shapeAnimationData.Item5 + "\" ";
                 animationAttributes += "data-animation-extra-" + i + "=\"" + shapeAnimationData.Item6 + "\" ";
+                animationAttributes += "data-animation-sound-" + i + "=\"" + SlideHelper.GetAudioURL(shapeAnimationData.Item8, Model) + "\" ";
                 animationAttributes += "data-animation-index-" + i + "=\"" + shapeAnimationData.Item7 + "\" ";
             }
         }

--- a/Aspose.Slides.WebExtensions/Templates/single-page/slide.html
+++ b/Aspose.Slides.WebExtensions/Templates/single-page/slide.html
@@ -21,7 +21,7 @@
 }
 
 @{
-    void EmitShape(IShape shape, Slide contextObject, bool animateTransitions, int slideNumber, Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int>>> slideAnimationData, bool hasNotes, bool isSlide)
+    void EmitShape(IShape shape, Slide contextObject, bool animateTransitions, int slideNumber, Dictionary<IShape, List<Tuple<string, string, float, float, string, string, int, IAudio>>> slideAnimationData, bool hasNotes, bool isSlide)
     {
         var margin = Model.Global.Get<int>("slideMargin");
         var visibleSlideNumber = animateTransitions ? 1 : slideNumber;
@@ -46,6 +46,7 @@
                 animationAttributes += "data-animation-delay=\"" + NumberHelper.ToCssNumber(shapeAnimationData.Item4) + "\" ";
                 animationAttributes += "data-animation-clickTarget=\"" + shapeAnimationData.Item5 + "\" ";
                 animationAttributes += "data-animation-extra=\"" + shapeAnimationData.Item6 + "\" ";
+                animationAttributes += "data-animation-sound=\"" + SlideHelper.GetAudioURL(shapeAnimationData.Item8, Model) + "\" ";
                 animationAttributes += "data-animation-index=\"" + shapeAnimationData.Item7 + "\" ";
             }
             else
@@ -60,6 +61,7 @@
                     animationAttributes += "data-animation-delay-" + i + "=\"" + NumberHelper.ToCssNumber(shapeAnimationData.Item4) + "\" ";
                     animationAttributes += "data-animation-clickTarget-" + i + "=\"" + shapeAnimationData.Item5 + "\" ";
                     animationAttributes += "data-animation-extra-" + i + "=\"" + shapeAnimationData.Item6 + "\" ";
+                    animationAttributes += "data-animation-sound-" + i + "=\"" + SlideHelper.GetAudioURL(shapeAnimationData.Item8, Model) + "\" ";
                     animationAttributes += "data-animation-index-" + i + "=\"" + shapeAnimationData.Item7 + "\" ";
                 }
             }


### PR DESCRIPTION
Adds support for animation-triggered audio in HTML5 export. Audio is exported as a separate resource and played with the associated animation. Adds functional coverage for exported audio and playback.